### PR TITLE
Bypass proguard cache when empty

### DIFF
--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -1072,7 +1072,7 @@ object Tasks {
       }.distinct :+ Attributed.blank(c)
       val extras = x map (f => file(f))
 
-      if (s && createDebug) {
+      if (s && createDebug && !pc.isEmpty) {
         st.log.debug("Proguard cache rules: " + pc)
         val deps = (cacheDir / "proguard_deps")
         val out = (cacheDir / "proguard_cache")


### PR DESCRIPTION
(Thank you very much for the great plugin.)

I feel it is convenient that we can bypass proguard cache by setting `proguardCache in Android := Seq.empty`. It works on my recent project using `android-sdk-plugin`.
