### PR TITLE
ProjectLayout shouldn't be sealed

### DIFF
--- a/src/ProjectLayout.scala
+++ b/src/ProjectLayout.scala
@@ -2,7 +2,7 @@ package android
 
 import sbt._
 
-sealed trait ProjectLayout {
+trait ProjectLayout {
   def base: File
   def scalaSource: File
   def javaSource: File


### PR DESCRIPTION
You can't know all of possible project layouts,
so let users implement their own, if needed, by extending this trait in their build.
