### PR TITLE
Fix aar with renderscript - include generated resources in package

### DIFF
--- a/sbt-test/android-sdk-plugin/renderscript/build.sbt
+++ b/sbt-test/android-sdk-plugin/renderscript/build.sbt
@@ -1,0 +1,7 @@
+import android.Keys._
+
+android.Plugin.androidBuildAar
+
+name := "renderscript"
+
+platformTarget in Android := "android-17"

--- a/sbt-test/android-sdk-plugin/renderscript/project/tests.scala
+++ b/sbt-test/android-sdk-plugin/renderscript/project/tests.scala
@@ -1,0 +1,25 @@
+import sbt._
+
+object Tests {
+  def findInArchive(archive: File)(predicate: String => Boolean): Boolean = {
+    import java.io._
+    import java.util.zip._
+    val in = new ZipInputStream(new FileInputStream(archive))
+    val found = Stream.continually(in.getNextEntry) takeWhile (
+      _ != null) exists (e => predicate(e.getName))
+
+    in.close()
+    found
+  }
+
+  def listArchive(archive: File): Seq[String] = {
+    import java.io._
+    import java.util.zip._
+    val in = new ZipInputStream(new FileInputStream(archive))
+    val found = Stream.continually(in.getNextEntry) takeWhile (
+      _ != null) map (_.getName) toList
+
+    in.close()
+    found
+  }
+}

--- a/sbt-test/android-sdk-plugin/renderscript/src/main/AndroidManifest.xml
+++ b/sbt-test/android-sdk-plugin/renderscript/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      package="com.example.app"
+      android:versionCode="1"
+      android:versionName="1.0">
+    <uses-sdk android:minSdkVersion="7" android:targetSdkVersion="15"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-feature android:name="android.hardware.touchscreen"
+                  android:required="false"/>
+
+    <application android:label="App Name (Use a String Resource)"
+                 android:debuggable="true"
+                 android:installLocation="auto"/>
+</manifest>

--- a/sbt-test/android-sdk-plugin/renderscript/src/main/rs/sample/invert.rs
+++ b/sbt-test/android-sdk-plugin/renderscript/src/main/rs/sample/invert.rs
@@ -1,0 +1,11 @@
+#pragma version(1)
+#pragma rs_fp_inprecise
+#pragma rs java_package_name(sample)
+
+uchar4 __attribute__((kernel)) invert(uchar4 in, uint32_t x, uint32_t y) {
+  uchar4 out = in;
+  out.r = 255 - in.r;
+  out.g = 255 - in.g;
+  out.b = 255 - in.b;
+  return out;
+}

--- a/sbt-test/android-sdk-plugin/renderscript/test
+++ b/sbt-test/android-sdk-plugin/renderscript/test
@@ -1,0 +1,8 @@
+> android:package
+> android:packageAar
+$ exists target/android-bin/renderscript-debug.apk
+$ exists target/android-bin/renderscript.aar
+> check-apk-for-resource
+> check-aar-for-resource
+> last android:apkbuild
+> show list-apk

--- a/sbt-test/android-sdk-plugin/renderscript/tests.sbt
+++ b/sbt-test/android-sdk-plugin/renderscript/tests.sbt
@@ -1,0 +1,16 @@
+import android.Keys._
+import Tests._
+
+TaskKey[Unit]("check-apk-for-resource") <<= (apkFile in Android) map { a =>
+  val found = findInArchive(a) (_ == "res/raw/invert.bc")
+  if (!found) error("Renderscript resource not found in APK\n" + listArchive(a))
+}
+
+TaskKey[Unit]("check-aar-for-resource") <<= (packageAar in Android) map { a =>
+  val found = findInArchive(a) (_ == "res/raw/invert.bc")
+  if (!found) error("Renderscript resource not found in Aar\n" + listArchive(a))
+}
+
+TaskKey[Seq[String]]("list-apk") <<= (apkFile in Android) map { a =>
+  listArchive(a)
+}

--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -420,6 +420,7 @@ object Tasks {
     val assetBin = layout.bin / "assets"
     val assets = layout.assets
     val resTarget = layout.bin / "resources" / "res"
+    val rsResources = layout.bin / "renderscript" / "res"
 
     resTarget.mkdirs()
     assetBin.mkdirs
@@ -433,8 +434,8 @@ object Tasks {
     if (noTestApk && layout.testAssets.exists)
       IO.copyDirectory(layout.testAssets, assetBin, false, true)
     // prepare resource sets for merge
-    val res = Seq(layout.res) ++ (libs map { _.layout.res } filter {
-      _.isDirectory })
+    val res = Seq(layout.res, rsResources) ++
+      (libs map { _.layout.res } filter { _.isDirectory })
 
     s.log.debug("Local/library-project resources: " + res)
     // this needs to wait for other projects to at least finish their
@@ -600,6 +601,7 @@ object Tasks {
                           ) map { case (j, layout, (_, r), n, s) =>
     import layout._
     val outfile = bin / (n + ".aar")
+    val rsRes = bin / "renderscript" / "res"
     s.log.info("Packaging " + outfile.getName)
     val mapping =
       (PathFinder(manifest)             x flat) ++
@@ -607,6 +609,7 @@ object Tasks {
       (PathFinder(bin / "proguard.txt") x flat) ++
       (PathFinder(j)                    x flat) ++
       ((PathFinder(res) ***)            x rebase(res,    "res")) ++
+      ((PathFinder(rsRes) ***)          x rebase(rsRes,  "res")) ++
       ((PathFinder(assets) ***)         x rebase(assets, "assets"))
     IO.jar(mapping, outfile, new java.util.jar.Manifest)
     outfile
@@ -828,7 +831,7 @@ object Tasks {
           (script relativeTo src).get.getParentFile.getPath).getAbsolutePath,
         //"-O", level, 0 through 3
         "-MD", "-p", layout.gen.getAbsolutePath,
-        "-o", (layout.bin / "resources" / "res" / "raw").getAbsolutePath) :+
+        "-o", (layout.bin / "renderscript" / "res" / "raw").getAbsolutePath) :+
           script.getAbsolutePath
 
       val r = cmd !


### PR DESCRIPTION
Changed packageAar task to use resources generated by collectResources instead of source resources.
Added a test to check if resource generated by renderscript is included in resulting aar and apk.
