### PR TITLE
fix #106 and #119 bump version to 1.3.7-SNAPSHOT + update proguard to 5.0 and asm to 5.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import ScriptedPlugin._
 
 name := "android-sdk-plugin"
 
-version := "1.3.6"
+version := "1.3.7-SNAPSHOT"
 
 organization := "com.hanhuy.sbt"
 
@@ -19,9 +19,9 @@ unmanagedBase <<= baseDirectory(_ / "libs")
 resourceDirectory in Compile <<= baseDirectory(_ / "resources")
 
 libraryDependencies ++= Seq(
-  "org.ow2.asm" % "asm-all" % "4.2",
+  "org.ow2.asm" % "asm-all" % "5.0.2",
   "javassist" % "javassist" % "3.12.1.GA",
-  "net.sf.proguard" % "proguard-base" % "4.11",
+  "net.sf.proguard" % "proguard-base" % "5.0",
   "com.android.tools.build" % "builder" % "0.12.2"
 )
 


### PR DESCRIPTION
This pull request possibly addresses #106 and #119. Tested with the macroid-starter project with jdk 1.8 + scala 2.11.2 + android platform-21 
