### PR TITLE
send classname to javah as list

### DIFF
--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -369,8 +369,7 @@ object Tasks {
       val javah = Seq("javah",
         "-d", src.getAbsolutePath,
         "-classpath", cp map (_.data.getAbsolutePath) mkString File.pathSeparator,
-        "-bootclasspath", bldr.getBootClasspath mkString File.pathSeparator,
-        natives mkString " ")
+        "-bootclasspath", bldr.getBootClasspath mkString File.pathSeparator) ++ natives
 
       s.log.debug(javah mkString " ")
 


### PR DESCRIPTION
When using multiple jni classes, the `ndkJavah` task failes with following exception.

```
Exception in thread "main" java.lang.IllegalArgumentException: Not a valid class name: net.surina.soundtouch.SoundTouch karuta.hpnpwd.audio.OggVorbisDecoder
```

This is because classname which passed to `javah` is a space joined classname. This pull request solves the problem.
