### PR TITLE
Simplify Packaging.apkbuild

### DIFF
--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -551,7 +551,7 @@ object Tasks {
     val s = streams.value
     val filter = ndkAbiFilter.value
     val logger = ilogger.value(s.log)
-    Packaging.apkbuild(builder.value(s.log), m, u, dcp, libraryProject.value, a,
+    Packaging.apkbuild(builder.value(s.log), Packaging.Jars(m, u, dcp), libraryProject.value, a,
       filter.toSet, layout.collectJni, layout.resources, layout.collectResource,
       layout.unsignedApk(a.apkbuildDebug, n), logger, s)
   }


### PR DESCRIPTION
There are two ideas behind this change:
* it makes argument list more obvious and short
* it strips some details from apkbuild body, so that they are easier to reason about

Old signature is kept as `@deprecated` in order to let dependant plugins make a graceful migration