### PR TITLE
Ndk bundle support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import ScriptedPlugin._
 import bintray.Keys._
 
-val pluginVersion = "1.6.0"
+val pluginVersion = "1.6.0-SNAPSHOT"
 val gradleBuildVersion = "1.2.0"
 
 val androidToolsVersion = "2.0.0"

--- a/src/ProjectLayout.scala
+++ b/src/ProjectLayout.scala
@@ -269,6 +269,7 @@ object SdkLayout {
     t.getLocation / "renderscript" / "lib"
   def renderscriptSupportLibs(t: BuildToolInfo) =
     (renderscriptSupportLibFile(t) * "*.jar").get
+  def ndkBundle(sdkPath: String) = file(sdkPath) / "ndk-bundle"
 
   def predex = file(AndroidLocation.getFolder) / "sbt" / "predex"
   def explodedAars = file(AndroidLocation.getFolder) / "sbt" / "exploded-aars"


### PR DESCRIPTION
Newest versions of android-sdk allows you to install ndk within sdk manager.
In this case you don't have any env vars or properties hinting where it is located, but we have sdk path and so we can just do a lookup for ndk location within sdk.