### PR TITLE
Reduced args count & boilerplate in Dex.

### DIFF
--- a/src/aggregates.scala
+++ b/src/aggregates.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import android.Dependencies.LibraryDependency
 import android.Keys.PackagingOptions
-import com.android.builder.core.AndroidBuilder
+import com.android.builder.core.{AndroidBuilder, DexOptions}
 import com.android.sdklib.BuildToolInfo
 import sbt.{Attributed, Logger}
 
@@ -61,7 +61,18 @@ object Aggregate {
                                   mainClassesConfig: File,
                                   minimizeMain: Boolean,
                                   buildTools: BuildToolInfo,
-                                  additionalParams: Seq[String])
+                                  additionalParams: Seq[String]) {
+    lazy val incremental = inputs._1 && !multi
+
+    def toDexOptions(incremental: Boolean = incremental) = new DexOptions {
+      override def getIncremental: Boolean = incremental
+      override def getJavaMaxHeapSize: String = maxHeap
+      override def getJumboMode: Boolean = false
+      override def getMaxProcessCount: Integer = maxProcessCount
+      override def getThreadCount: Integer = Runtime.getRuntime.availableProcessors()
+      override def getPreDexLibraries: Boolean = false
+    }
+  }
 
   private[android] case class Proguard(useProguard: Boolean,
                                        useProguardInDebug: Boolean,

--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -1061,7 +1061,6 @@ object Tasks {
     if (ta.libraryProject)
       Plugin.fail("This project cannot `android:test`, it has set 'libraryProject := true")
     implicit val output = o
-    val xmx = ta.dexMaxHeap
     val pkg = ma.applicationId
     val minSdk = ma.minSdkVersion
     val targetSdk = ma.targetSdkVersion
@@ -1105,7 +1104,7 @@ object Tasks {
         override def getIncremental = true
         override def getJumboMode = false
         override def getPreDexLibraries = false
-        override def getJavaMaxHeapSize = xmx
+        override def getJavaMaxHeapSize = ta.dexMaxHeap
         override def getThreadCount = java.lang.Runtime.getRuntime.availableProcessors()
         override def getMaxProcessCount = ta.dexMaxProcessCount
       }


### PR DESCRIPTION
Logic for DexOptions was encapsulated within Aggregate.Dex,
since it purely based on Aggregate.Dex members.
This makes it easier to inspect options usage and reduces boilerplate around it.