### PR TITLE
Added support for activity-alias

### DIFF
--- a/src/parsers.scala
+++ b/src/parsers.scala
@@ -21,7 +21,7 @@ import collection.JavaConverters._
 private[android] object parsers {
   val ACTION_MAIN = "android.intent.action.MAIN"
   def activityName(n: Node) = n.attribute(Resources.ANDROID_NS, "name").head.text
-  def findMainActivitySeq(element: Elem): NodeSeq = {
+  def findMainActivities(element: Elem): NodeSeq = {
     for {
       a <- (element \\ "activity" ++ element \\ "activity-alias")
       i <- a \ "intent-filter" \ "action"
@@ -36,7 +36,7 @@ private[android] object parsers {
         pkg <- appid
       } yield {
         val manifest = XML.loadFile(f)
-        val names = findMainActivitySeq(manifest) map activityName
+        val names = findMainActivities(manifest) map activityName
         EOF.map(_ => None) | (Space ~> opt(
           (token(StringBasic.examples(pkg + "/")) ~ token(StringBasic.examples(names:_*)))
             .map { case (a,b) => a + b }

--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -1274,7 +1274,7 @@ object Tasks {
     val manifestXml = l.processedManifest
     val m = XML.loadFile(manifestXml)
     // if an arg is specified, try to launch that
-    parsers.activityParser.parsed orElse (parsers.findMainActivitySeq(m).headOption.map(activity => {
+    parsers.activityParser.parsed orElse (parsers.findMainActivities(m).headOption.map(activity => {
       val name = activity.attribute(ANDROID_NS, "name").get.head.text
       "%s/%s" format (p, if (name.indexOf(".") == -1) "." + name else name)
     })) match {


### PR DESCRIPTION
Hello there. I noticed that there is 
> No activity found with action 'android.intent.action.MAIN'

when running "**android:run**" while I have only just activity aliases with this action. We use [that feature](http://blog.danlew.net/2014/01/16/preserve-your-launchers-use-activity-alias/), so it's too uncomfortable to start it by fingers >.<

Also there is minor code duplication cleanup. Tell me if I broke something.