### PR TITLE
travis-based ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: android
+os:
+  - linux
+jdk:
+  - oraclejdk8
+cache:
+  directories:
+    - $HOME/.m2/repository
+    - $HOME/.sbt
+    - $HOME/.ivy2
+android:
+  components:
+    - sys-img-armeabi-v7a-android-21
+    - build-tools-22.0.1
+    - build-tools-23.0.1
+    - platform-tools
+    - tools
+    - extra
+# Emulator Management: Create, Start and Wait
+before_script:
+  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+  - emulator -avd test -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+script:
+  - curl -o sbt-launcher.sh https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt
+  - chmod a+x ./sbt-launcher.sh
+  - ./sbt-launcher.sh compile scripted

--- a/sbt-test/android-sdk-plugin/android-test-kit/build.sbt
+++ b/sbt-test/android-sdk-plugin/android-test-kit/build.sbt
@@ -13,3 +13,5 @@ lazy val flavor1 = android.Plugin.flavorOf(root, "flavor1",
 debugIncludesTests in Android := false
 
 autoScalaLibrary := false
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/auto-build/build.sbt
+++ b/sbt-test/android-sdk-plugin/auto-build/build.sbt
@@ -3,3 +3,5 @@ transitiveAndroidLibs in Android := false
 libraryDependencies += "com.android.support" % "appcompat-v7" % "19.1.0" % "test"
 
 minSdkVersion := "7"
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/hello-jni/build.sbt
+++ b/sbt-test/android-sdk-plugin/hello-jni/build.sbt
@@ -1,0 +1,1 @@
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/hello-multidex/build.sbt
+++ b/sbt-test/android-sdk-plugin/hello-multidex/build.sbt
@@ -52,3 +52,5 @@ packagingOptions in Android := PackagingOptions(excludes = Seq(
 ))
 
 javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6")
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/hello-world-gradle-layout/build.sbt
+++ b/sbt-test/android-sdk-plugin/hello-world-gradle-layout/build.sbt
@@ -7,3 +7,5 @@ platformTarget in Android := "android-17"
 name := "hello-world"
 
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/hello-world-oscarvarto/build.sbt
+++ b/sbt-test/android-sdk-plugin/hello-world-oscarvarto/build.sbt
@@ -7,3 +7,5 @@ platformTarget in Android := "android-17"
 name := "hello-world"
 
 javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6")
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/hello-world-scala-gradle-layout/build.sbt
+++ b/sbt-test/android-sdk-plugin/hello-world-scala-gradle-layout/build.sbt
@@ -9,3 +9,5 @@ scalaVersion := "2.11.2"
 name := "hello-world"
 
 javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6")
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/lib-with-resources/build.sbt
+++ b/sbt-test/android-sdk-plugin/lib-with-resources/build.sbt
@@ -5,3 +5,5 @@ android.Plugin.androidBuild
 name := "lib-with-resources"
 
 platformTarget in Android := "android-17"
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/multiproject-lib-with-resources/lib-with-resources/build.sbt
+++ b/sbt-test/android-sdk-plugin/multiproject-lib-with-resources/lib-with-resources/build.sbt
@@ -3,3 +3,5 @@ import android.Keys._
 name := "lib-with-resources"
 
 platformTarget in Android := "android-17"
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/multiproject-lib-with-resources/project/build.scala
+++ b/sbt-test/android-sdk-plugin/multiproject-lib-with-resources/project/build.scala
@@ -33,6 +33,7 @@ object MyProjectBuild extends Build {
                         "org.slf4j" % "slf4j-simple" % "1.7.5"))
 
   lazy val appSettings = List(
+        showSdkProgress in Android := false,
         platformTarget in Android := "android-17",
         useProguard in Android := true,
         useProguardInDebug in Android := true,

--- a/sbt-test/android-sdk-plugin/multiproject-retrolambda/build.sbt
+++ b/sbt-test/android-sdk-plugin/multiproject-retrolambda/build.sbt
@@ -15,3 +15,5 @@ lazy val `test`			= project in file(".") aggregate `test-client`
 lazy val `test-client`	= project in file("sub/client")
 		
 TaskKey[File]("bundle")	:= (android.Keys.packageDebug	in (`test-client`, android.Keys.Android)).value
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/multiproject-retrolambda/sub/client/build.sbt
+++ b/sbt-test/android-sdk-plugin/multiproject-retrolambda/sub/client/build.sbt
@@ -10,3 +10,5 @@ platformTarget in Android		:= "android-19"
 dexAdditionalParams	in Android	+= "--core-library"
 
 proguardOptions in Android += "-ignorewarnings"
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/multiproject-same-dependencies/build.sbt
+++ b/sbt-test/android-sdk-plugin/multiproject-same-dependencies/build.sbt
@@ -1,12 +1,14 @@
 javacOptions in Global ++= List("-source", "1.7", "-target", "1.7")
 
-val b = project.settings(androidBuildAar:_*).settings(platformTarget := "android-23")
+val sharedSettings = Seq(platformTarget := "android-23", showSdkProgress in Android := false)
 
-val c = project.settings(androidBuildAar:_*).settings(platformTarget := "android-23")
+val b = project.settings(androidBuildAar:_*).settings(sharedSettings: _*)
 
-val d = project.settings(androidBuildAar:_*).settings(platformTarget := "android-23")
+val c = project.settings(androidBuildAar:_*).settings(sharedSettings: _*)
 
-val a = project.androidBuildWith(b,c,d).settings(platformTarget := "android-23")
+val d = project.settings(androidBuildAar:_*).settings(sharedSettings: _*)
+
+val a = project.androidBuildWith(b,c,d).settings(sharedSettings: _*)
 
 libraryDependencies in b += "com.android.support" % "appcompat-v7" % "23.1.1"
 

--- a/sbt-test/android-sdk-plugin/multiproject-with-resources/project/Build.scala
+++ b/sbt-test/android-sdk-plugin/multiproject-with-resources/project/Build.scala
@@ -13,7 +13,8 @@ object Build extends Build {
         "com.scalatags" % "scalatags_2.10" % "0.2.4"
       ),
       scalaVersion := "2.10.2",
-      javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6")
+      javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6"),
+      showSdkProgress in Android := false
     )
   ) dependsOn core
 

--- a/sbt-test/android-sdk-plugin/proguard-cache-duplicate-classes/build.sbt
+++ b/sbt-test/android-sdk-plugin/proguard-cache-duplicate-classes/build.sbt
@@ -33,3 +33,5 @@ proguardCache in Android ++=
 
 
 javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6")
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/proguard-cache/build.sbt
+++ b/sbt-test/android-sdk-plugin/proguard-cache/build.sbt
@@ -11,3 +11,5 @@ libraryDependencies += "com.android.support" % "support-v4" % "18.0.0"
 proguardCache in Android += "android.support"
 
 javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6")
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/renderscript-support-v8/build.sbt
+++ b/sbt-test/android-sdk-plugin/renderscript-support-v8/build.sbt
@@ -7,6 +7,8 @@ name := "renderscript-support-v8"
 platformTarget in Android := "android-21"
 
 // need to target different versions on 23.+
-buildToolsVersion in Android := Some("23.0.3")
+buildToolsVersion in Android := Some("22.0.1")
 
 minSdkVersion := "8"
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/renderscript/build.sbt
+++ b/sbt-test/android-sdk-plugin/renderscript/build.sbt
@@ -8,3 +8,5 @@ platformTarget in Android := "android-17"
 
 // need to target different versions on 23.+
 buildToolsVersion in Android := Some("22.0.1")
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/robo-junit-test/build.sbt
+++ b/sbt-test/android-sdk-plugin/robo-junit-test/build.sbt
@@ -11,3 +11,5 @@ exportJars in Test := false // necessary until android-sdk-plugin 1.3.12
  
 // or else @Config throws an exception, yay
 unmanagedClasspath in Test ++= (bootClasspath in Android).value
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/simple-ant-layout/build.sbt
+++ b/sbt-test/android-sdk-plugin/simple-ant-layout/build.sbt
@@ -3,3 +3,5 @@ import android.Keys._
 android.Plugin.androidBuild
 
 platformTarget in Android := "android-17"
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/simple-gradle-layout/build.sbt
+++ b/sbt-test/android-sdk-plugin/simple-gradle-layout/build.sbt
@@ -7,3 +7,5 @@ platformTarget in Android := "android-17"
 libraryDependencies += "com.google.android.gms" % "play-services" % "4.3.23"
 
 resValues in Android += ("string", "test_resource", "test value")
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/simple-jar/build.sbt
+++ b/sbt-test/android-sdk-plugin/simple-jar/build.sbt
@@ -1,3 +1,5 @@
 androidBuildJar
 
 platformTarget in Android := "android-22"
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/simple-retrolambda/build.sbt
+++ b/sbt-test/android-sdk-plugin/simple-retrolambda/build.sbt
@@ -3,3 +3,5 @@ retrolambdaEnabled in Android := true
 libraryDependencies += "com.google.guava" % "guava" % "18.0"
 
 autoScalaLibrary := false
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/typed-resources/build.sbt
+++ b/sbt-test/android-sdk-plugin/typed-resources/build.sbt
@@ -1,3 +1,5 @@
 javacOptions in Compile ++= "-source" :: "1.7" :: "-target" :: "1.7" :: Nil
 
 minSdkVersion := "8"
+
+showSdkProgress in Android := false

--- a/sbt-test/android-sdk-plugin/with-scalatest/build.sbt
+++ b/sbt-test/android-sdk-plugin/with-scalatest/build.sbt
@@ -1,3 +1,5 @@
 scalaVersion := "2.11.7"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.5" % "test"
+
+showSdkProgress in Android := false


### PR DESCRIPTION
[![Build Status](https://travis-ci.org/dant3/android-sdk-plugin.svg?branch=ci)](https://travis-ci.org/dant3/android-sdk-plugin)

**Changes:**
* `android-sdk-plugin/renderscript-support-v8` testcase uses downgraded renderscript version in order to avoid missing `libncurses` which is needed by `build-tools/23.0.3/llvm-rs-cc`. This should be fixed on travis side one day, or, could be worked around with downloading/building a `libncurses.so.5` into the local directory and `LD_LIBRARY_PATH` it
* most testcases got `showSdkProgress in Android := false` option in order to reduce console output. This is needed mostly for travis - it fails builds if logged console output exceedes 4mb, which happens with ease then installing ndk for instance

**That to do next:**
Just go to https://travis-ci.org and enable it for this project - and it should just work. More things to consider here is caching of `~/.android` (will makes build somewhat faster but has drawbacks) and running build on other os environments in order to check if integration tests can run there as well.

**Alternatives**
I also evaluated wercker and ended up not using it due to issues with running emulator. Just for the sake of reference here is the configuration I ended up with for wercker:
* [wercker.yml](https://gist.github.com/dant3/f2f56ec904c7f7b859c78956edf3e814#file-wercker-yml)
* [Dockerfile for image used in wercker.yml](https://github.com/dant3/docker/blob/1b8e4d3eb73cc2a463575a1d2517207ad70076f6/android/Dockerfile)