### PR TITLE
Fix missing workarounds for race conditions in google android tools

### DIFF
--- a/src/rules.scala
+++ b/src/rules.scala
@@ -745,10 +745,9 @@ object Plugin extends sbt.Plugin with PluginFail {
       val sdkHandler = sdkManager.value
       val showProgress = showSdkProgress.value
       buildToolsVersion.value map { version =>
-        AndroidPlugin.retryWhileFailed(
-          "Failed to fetch build tool info, retrying...", slog)(
-          sdkHandler.getBuildToolInfo(Revision.parseRevision(version), ind))
-        val bti = sdkHandler.getBuildToolInfo(Revision.parseRevision(version), ind)
+        val bti = AndroidPlugin.retryWhileFailed("Failed to fetch build tool info, retrying...", slog) {
+          sdkHandler.getBuildToolInfo(Revision.parseRevision(version), ind)
+        }
         if (bti == null) {
           slog.warn(s"build-tools $version not found, searching for package...")
           SdkInstaller.installPackage(sdkHandler, "build-tools;", version, "build-tools " + version, showProgress, slog)


### PR DESCRIPTION
fetching build tool info was retried but the result of the retry mechanism
was never used, instead it was fetched again without retry ...
and occasionally failed.