### PR TITLE
Allow builds to add rules for mainDexClasses list generation

### DIFF
--- a/src/keys.scala
+++ b/src/keys.scala
@@ -219,6 +219,10 @@ object Keys {
     "Maximum process count for dex, default available processor count") in Android
   val dexMulti = SettingKey[Boolean]("dex-multi",
     "multi-dex flag for dex, default false") in Android
+  val dexMainClassesRules = SettingKey[Seq[String]](
+    "dex-main-classes-rules",
+    "The proguard rules applied when generating the dex main classes list for mutli-dex build."
+  ) in Android
   val dexMainClasses = SettingKey[Seq[String]]("dex-main-classes",
     "list of class files that go into main-dex-list parameter for dex") in Android
   val dexMinimizeMain = SettingKey[Boolean]("dex-minimize-main",

--- a/src/rules.scala
+++ b/src/rules.scala
@@ -542,9 +542,7 @@ object Plugin extends sbt.Plugin with PluginFail {
       "-forceprocessing",
       "-keep public class * extends android.app.backup.BackupAgent { <init>(); }",
       "-keep public class * extends java.lang.annotation.Annotation { *; }",
-      "-keep class android.support.multidex.** { *; }",
-      "-keep class com.android.tools.fd.** { *; }",
-      "-dontnote com.android.tools.fd.**,android.support.multidex.MultiDexExtractor"
+      "-keep class android.support.multidex.** { *; }"
     ),
     dexMainClasses           := Seq.empty,
     dexMinimizeMain          := false,

--- a/src/rules.scala
+++ b/src/rules.scala
@@ -495,10 +495,10 @@ object Plugin extends sbt.Plugin with PluginFail {
     ndkBuild                <<= ndkBuildTaskDef,
     aidl                    <<= aidlTaskDef,
     rsTargetApi             <<= (properties, minSdkVersion) map { (p, m) =>
-      Option(p.getProperty("renderscript.target")).getOrElse(m) 
+      Option(p.getProperty("renderscript.target")).getOrElse(m)
     },
-    rsSupportMode           <<= properties { p => 
-      Try(p.getProperty("renderscript.support.mode").toBoolean).getOrElse(false) 
+    rsSupportMode           <<= properties { p =>
+      Try(p.getProperty("renderscript.support.mode").toBoolean).getOrElse(false)
     },
     rsOptimLevel            := 3,
     renderscript            <<= renderscriptTaskDef,
@@ -533,6 +533,19 @@ object Plugin extends sbt.Plugin with PluginFail {
     dexMaxHeap               := "1024m",
     dexMaxProcessCount       := java.lang.Runtime.getRuntime.availableProcessors,
     dexMulti                 := false,
+    dexMainClassesRules      := Seq(
+      "-dontobfuscate",
+      "-dontoptimize",
+      "-dontpreverify",
+      "-dontwarn **",
+      "-dontnote **",
+      "-forceprocessing",
+      "-keep public class * extends android.app.backup.BackupAgent { <init>(); }",
+      "-keep public class * extends java.lang.annotation.Annotation { *; }",
+      "-keep class android.support.multidex.** { *; }",
+      "-keep class com.android.tools.fd.** { *; }",
+      "-dontnote com.android.tools.fd.**,android.support.multidex.MultiDexExtractor"
+    ),
     dexMainClasses           := Seq.empty,
     dexMinimizeMain          := false,
     dexAdditionalParams      := Seq.empty,

--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -837,10 +837,18 @@ object Tasks {
 
   val dexMainClassesConfigTaskDef = Def.task {
     implicit val output = outputLayout.value
-    Dex.dexMainClassesConfig(processManifest.value,
-      (managedClasspath in AndroidInternal).value, projectLayout.value,
-      dexLegacyMode.value, dexMulti.value, dexInputs.value._2,
-      dexMainClasses.value, buildTools.value, streams.value)
+    Dex.dexMainClassesConfig(
+      processManifest.value,
+      (managedClasspath in AndroidInternal).value,
+      projectLayout.value,
+      dexLegacyMode.value,
+      dexMulti.value,
+      dexMainClassesRules.value,
+      dexInputs.value._2,
+      dexMainClasses.value,
+      buildTools.value,
+      streams.value
+    )
   }
 
   val retrolambdaAggregateTaskDef = Def.task {


### PR DESCRIPTION
 - via new setting key dexMainClassesRules
 - additionally added missing keep rule for 'android.support.multidex.**'