### PR TITLE
Added option to disable full of resources at TR.scala

### DIFF
--- a/src/keys.scala
+++ b/src/keys.scala
@@ -81,6 +81,8 @@ object Keys {
     "TR.scala generating task") in Android
   val typedResources = SettingKey[Boolean]("typed-resources",
     "flag indicating whether to generated TR.scala") in Android
+  val typedResourcesFull = SettingKey[Boolean]("typed-resources-full",
+    "whether full of resources should be generated at TR.scala, default true") in Android
   val typedResourcesIgnores = SettingKey[Seq[String]]("typed-resources-ignores",
     "list of android package names to ignore for TR.scala generation") in Android
   val buildConfigGenerator = TaskKey[Seq[File]]("build-config-generator",

--- a/src/resources.scala
+++ b/src/resources.scala
@@ -298,7 +298,7 @@ object Resources {
 
   def generateTR(t: Boolean, a: Seq[File], p: String, layout: ProjectLayout,
                  platformApi: Int, platform: (String,Seq[String]), sv: String,
-                 l: Seq[LibraryDependency], i: Seq[String], s: TaskStreams): Seq[File] = {
+                 l: Seq[LibraryDependency], f: Boolean, i: Seq[String], s: TaskStreams): Seq[File] = {
 
     val j = platform._1
     val r = layout.res
@@ -374,13 +374,14 @@ object Resources {
 
           tr.delete()
 
-          val resdirs = r +:
-            (for {
+          val resdirs = if (f) {
+            r +: (for {
               lib <- l filterNot {
                 case p: Dependencies.Pkg => ignores(p.pkg)
                 case _                   => false
               }
             } yield lib.getResFolder)
+          } else Nil
           val rms1 = processValuesXml(resdirs, s)
           val rms2 = processResourceTypeDirs(resdirs, s)
           val combined = reduceResourceMap(Seq(rms1, rms2)).filter(_._2.nonEmpty)

--- a/src/rules.scala
+++ b/src/rules.scala
@@ -599,6 +599,7 @@ object Plugin extends sbt.Plugin with PluginFail {
     proguardScala           <<= autoScalaLibrary,
     retrolambdaEnabled       := false,
     typedResources          <<= autoScalaLibrary,
+    typedResourcesFull       := true,
     typedResourcesIgnores    := Seq.empty,
     typedResourcesGenerator <<= typedResourcesGeneratorTaskDef,
     useProguard             <<= proguardScala,

--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -299,7 +299,7 @@ object Tasks {
     Resources.generateTR(typedResources.value, rGenerator.value,
       packageForR.value, projectLayout.value, platformApi.value,
       platformJars.value, (scalaVersion in ThisProject).value,
-      libraryProjects.value, typedResourcesIgnores.value, streams.value)
+      libraryProjects.value, typedResourcesFull.value, typedResourcesIgnores.value, streams.value)
   }
 
   def ndkbuild(manager: AndroidSdkHandler, layout: ProjectLayout, args: Seq[String],


### PR DESCRIPTION
Last build of my big project became slower for about 1 min.
So my TR.scala became too fat ~ 3500 LOC (was ~1000), but I don't need for all typed resources.