### PR TITLE
New setting typedResourcesIds

### DIFF
--- a/src/keys.scala
+++ b/src/keys.scala
@@ -85,6 +85,8 @@ object Keys {
     "viewHolders.scala generating task") in Android
   val typedResources = SettingKey[Boolean]("typed-resources",
     "flag indicating whether to generated TR.scala") in Android
+  val typedResourcesIds = SettingKey[Boolean]("typed-resources-ids",
+    "whether to generate TR ids") in Android
   val typedResourcesFull = SettingKey[Boolean]("typed-resources-full",
     "whether full of resources should be generated at TR.scala, default true") in Android
   val typedResourcesAar = SettingKey[Boolean]("typed-resources-aar",

--- a/src/keys.scala
+++ b/src/keys.scala
@@ -86,7 +86,7 @@ object Keys {
   val typedResources = SettingKey[Boolean]("typed-resources",
     "flag indicating whether to generated TR.scala") in Android
   val typedResourcesIds = SettingKey[Boolean]("typed-resources-ids",
-    "whether to generate TR ids") in Android
+    "whether to generate TR ids, default true") in Android
   val typedResourcesFull = SettingKey[Boolean]("typed-resources-full",
     "whether full of resources should be generated at TR.scala, default true") in Android
   val typedResourcesAar = SettingKey[Boolean]("typed-resources-aar",

--- a/src/resources.scala
+++ b/src/resources.scala
@@ -495,7 +495,7 @@ object Resources {
               resources map { case (k,v) =>
                 "  final val %s = TypedResource[%s](R.id.%s)" format (wrap(k),v,wrap(k))
               } mkString "\n"
-            } else "  // Id generation disabled via typedResourcesIds := false",
+            } else "  // TypedResource ID generation disabled by 'typedResourcesIds := false'",
             layoutTypes map { case (k,v) =>
               "    final val %s = TypedLayout[%s](R.layout.%s)" format (wrap(k),v,wrap(k))
             } mkString "\n", trs.mkString, getColor, getDrawable, getDrawable, deprForward) replace ("\r", ""))

--- a/src/resources.scala
+++ b/src/resources.scala
@@ -393,17 +393,13 @@ object Resources {
             l      <- classForLabel(j, layout.label).orElse(Some("android.view.View"))
           } yield file.getName.stripSuffix(".xml") -> l)
 
-          val resources = ids match {
-            case true =>
-              warn(for {
-                b      <- layouts
-                layout  = XML loadFile b
-                n      <- layout.descendant_or_self
-                re(id) <- n.attribute(ANDROID_NS, "id") map { _.head.text }
-                l      <- classForLabel(j, n.label)
-              } yield id -> l)
-            case false => Map.empty[String, String]
-          }
+          val resources = if (ids) warn(for {
+            b      <- layouts
+            layout  = XML loadFile b
+            n      <- layout.descendant_or_self
+            re(id) <- n.attribute(ANDROID_NS, "id") map { _.head.text }
+            l      <- classForLabel(j, n.label)
+          } yield id -> l) else Map.empty
 
           val trTemplate = IO.readLinesURL(
             resourceUrl("tr.scala.template")) mkString "\n"

--- a/src/resources.scala
+++ b/src/resources.scala
@@ -340,7 +340,7 @@ object Resources {
   }
   def generateTR(t: Boolean, a: Seq[File], p: String, layout: ProjectLayout,
                  platformApi: Int, platform: (String,Seq[String]), sv: String,
-                 l: Seq[LibraryDependency], f: Boolean, includeAar: Boolean,
+                 l: Seq[LibraryDependency], f: Boolean, ids: Boolean, includeAar: Boolean,
                  withViewHolders: Boolean, i: Seq[String], s: TaskStreams): Seq[File] = {
 
     val j = platform._1

--- a/src/resources.scala
+++ b/src/resources.scala
@@ -393,13 +393,17 @@ object Resources {
             l      <- classForLabel(j, layout.label).orElse(Some("android.view.View"))
           } yield file.getName.stripSuffix(".xml") -> l)
 
-          val resources = warn(for {
-            b      <- layouts
-            layout  = XML loadFile b
-            n      <- layout.descendant_or_self
-            re(id) <- n.attribute(ANDROID_NS, "id") map { _.head.text }
-            l      <- classForLabel(j, n.label)
-          } yield id -> l)
+          val resources = ids match {
+            case true =>
+              warn(for {
+                b      <- layouts
+                layout  = XML loadFile b
+                n      <- layout.descendant_or_self
+                re(id) <- n.attribute(ANDROID_NS, "id") map { _.head.text }
+                l      <- classForLabel(j, n.label)
+              } yield id -> l)
+            case false => Map.empty[String, String]
+          }
 
           val trTemplate = IO.readLinesURL(
             resourceUrl("tr.scala.template")) mkString "\n"
@@ -487,9 +491,11 @@ object Resources {
 
           IO.write(tr, trTemplate format (p,
             if (withViewHolders) "" else  " extends AnyVal",
-            resources map { case (k,v) =>
-              "  final val %s = TypedResource[%s](R.id.%s)" format (wrap(k),v,wrap(k))
-            } mkString "\n",
+            if (ids) {
+              resources map { case (k,v) =>
+                "  final val %s = TypedResource[%s](R.id.%s)" format (wrap(k),v,wrap(k))
+              } mkString "\n"
+            } else "  // Id generation disabled via typedResourcesIds := false",
             layoutTypes map { case (k,v) =>
               "    final val %s = TypedLayout[%s](R.layout.%s)" format (wrap(k),v,wrap(k))
             } mkString "\n", trs.mkString, getColor, getDrawable, getDrawable, deprForward) replace ("\r", ""))

--- a/src/rules.scala
+++ b/src/rules.scala
@@ -565,6 +565,7 @@ object Plugin extends sbt.Plugin with PluginFail {
     proguardScala           <<= autoScalaLibrary,
     retrolambdaEnabled       := false,
     typedResources          <<= autoScalaLibrary,
+    typedResourcesIds        := true,
     typedResourcesFull       := true,
     typedResourcesAar        := false,
     typedViewHolders        <<= autoScalaLibrary,

--- a/src/tasks.scala
+++ b/src/tasks.scala
@@ -340,8 +340,8 @@ object Tasks extends TaskBase {
     Resources.generateTR(typedResources.value, rGenerator.value,
       packageForR.value, projectLayout.value, platformApi.value,
       platformJars.value, (scalaVersion in ThisProject).value,
-      libraryProjects.value, typedResourcesFull.value, typedResourcesAar.value,
-      typedViewHolders.value,
+      libraryProjects.value, typedResourcesFull.value, typedResourcesIds.value,
+      typedResourcesAar.value, typedViewHolders.value,
       typedResourcesIgnores.value, streams.value)
   }
 


### PR DESCRIPTION
This setting allows to disable the generation of `TypedResource[_]` fields in `TR` which is kinda obsolete when using the new `TypedViewHolder`. By default, the setting is set to true so that no user-action is required when updating.