### PR TITLE
Add menu items to TR.scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import ScriptedPlugin._
 import bintray.Keys._
 
-val pluginVersion = "1.7.7"
+val pluginVersion = "1.7.7-SNAPSHOT"
 val gradleBuildVersion = "1.3.2"
 
 val androidToolsVersion = "2.2.0"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import ScriptedPlugin._
 import bintray.Keys._
 
-val pluginVersion = "1.7.7-SNAPSHOT"
+val pluginVersion = "1.7.7"
 val gradleBuildVersion = "1.3.2"
 
 val androidToolsVersion = "2.2.0"

--- a/resources/tr.scala.template
+++ b/resources/tr.scala.template
@@ -6,15 +6,19 @@ import android.content.Context
 import android.content.res.{TypedArray,XmlResourceParser}
 import android.graphics.drawable.Drawable
 import android.os.Build
-import android.view.{View,ViewGroup,LayoutInflater}
+import android.view.{View,ViewGroup,LayoutInflater, MenuInflater, Menu, MenuItem}
 import android.view.animation.{Animation, AnimationUtils, Interpolator}
 import android.animation.{Animator, AnimatorInflater}
 
 import scala.annotation.implicitNotFound
 
+trait MenuItemExtractor { self: TypedRes[_] =>
+  def unapply(mi: MenuItem): Boolean = if (mi.getItemId == resid) true else false
+}
+
 case class TypedResource[A](id: Int) extends AnyVal
 case class TypedLayout[A](id: Int)%s
-case class TypedRes[A](resid: Int) extends AnyVal {
+case class TypedRes[A](resid: Int) extends MenuItemExtractor {
   def value(implicit ev: TypedResource.TypedResValueOp[A], c: Context): ev.T = ev.resourceValue(resid)(c)
 }
 
@@ -45,6 +49,7 @@ object TypedResource {
   sealed trait ResInteger
   sealed trait ResInterpolator
   sealed trait ResMenu
+  sealed trait ResMenuItem
   sealed trait ResMipMap
   sealed trait ResPlurals
   sealed trait ResRaw
@@ -83,6 +88,18 @@ object TypedResource {
       inflate(tl, c, true)
     def inflate[A <: View](tl: TypedLayout[A]): A =
       inflate(tl, null, false)
+  }
+
+  implicit class TypedResMenuInflater(val mi: MenuInflater) extends AnyVal {
+    def inflate(menuRes: TypedRes[ResMenu], menu: Menu): Unit = {
+      mi.inflate(menuRes.resid, menu)
+    }
+  }
+
+  implicit class TypedResMenuOps(val m: Menu) extends AnyVal {
+    def findItem(item: TypedRes[ResMenuItem]): MenuItem = {
+      m.findItem(item.resid)
+    }
   }
 
   implicit val trAnimValueOp: TypedResValueOp[ResAnim] { type T = Animation } = new TypedResValueOp[ResAnim] {

--- a/resources/tr.scala.template
+++ b/resources/tr.scala.template
@@ -66,7 +66,7 @@ object TypedResource {
     def resourceValue(resid: Int)(implicit c: Context): T
   }
 
-  @implicitNotFound("didn't find an extractor for ${A}, create an Extractor[${A}] manually")
+  @implicitNotFound("didn't find an extractor for ${A},${T}; create an Extractor[${A},${T}] manually")
   trait Extractor[A,T] {
     def matches(resid: Int, t: T): Boolean
   }

--- a/resources/tr.scala.template
+++ b/resources/tr.scala.template
@@ -12,14 +12,12 @@ import android.animation.{Animator, AnimatorInflater}
 
 import scala.annotation.implicitNotFound
 
-trait MenuItemExtractor { self: TypedRes[_] =>
-  def unapply(mi: MenuItem): Boolean = if (mi.getItemId == resid) true else false
-}
-
 case class TypedResource[A](id: Int) extends AnyVal
 case class TypedLayout[A](id: Int)%s
-case class TypedRes[A](resid: Int) extends MenuItemExtractor {
+case class TypedRes[A](resid: Int) extends AnyVal {
   def value(implicit ev: TypedResource.TypedResValueOp[A], c: Context): ev.T = ev.resourceValue(resid)(c)
+
+  def unapply[T,A](t: T)(implicit ex: TypedResource.Extractor[A,T]): Boolean = ex.matches(resid, t)
 }
 
 object TR {
@@ -67,6 +65,11 @@ object TypedResource {
   trait TypedResValueOp[A] {
     type T
     def resourceValue(resid: Int)(implicit c: Context): T
+  }
+
+  @implicitNotFound("didn't find an extractor for ${A}, create an Extractor[${A}] manually")
+  trait Extractor[A,T] {
+    def matches(resid: Int, t: T): Boolean
   }
 
   implicit class TypedView(val v: View) extends AnyVal with TypedFindView {
@@ -182,6 +185,9 @@ object TypedResource {
     type T = XmlResourceParser
     @inline final def resourceValue(resid: Int)(implicit c: Context): T =
       c.getResources.getXml(resid)
+  }
+  implicit val menuItemExtractor: Extractor[ResMenuItem, MenuItem] = new Extractor[ResMenuItem, MenuItem] {
+    @inline final def matches(resid: Int, mi: MenuItem): Boolean = (mi.getItemId == resid)
   }
 
 %s

--- a/resources/tr.scala.template
+++ b/resources/tr.scala.template
@@ -16,8 +16,7 @@ case class TypedResource[A](id: Int) extends AnyVal
 case class TypedLayout[A](id: Int)%s
 case class TypedRes[A](resid: Int) extends AnyVal {
   def value(implicit ev: TypedResource.TypedResValueOp[A], c: Context): ev.T = ev.resourceValue(resid)(c)
-
-  def unapply[T,A](t: T)(implicit ex: TypedResource.Extractor[A,T]): Boolean = ex.matches(resid, t)
+  def unapply[A,T](t: T)(implicit ex: TypedResource.Extractor[A,T]): Boolean = ex.matches(resid, t)
 }
 
 object TR {


### PR DESCRIPTION
Menu items are currently not included in TR.scala. This PR adds menu items to the typed resources as part of object menu_items, for example:
```scala
object menu_item {
    final val sort = TypedRes[TypedResource.ResMenuItem](R.id.sort)
    final val clear = TypedRes[TypedResource.ResMenuItem](R.id.clear)
}
```

It also adds an extractor for ```MenuItem``` to the TypedRes class allowing to match on menu items directly, for example instead of:
```scala
item.getItemId match {
      case TR.menu_item.sort.resid =>...
      case TR.menu_item.clear.resid =>...
      case _ => ...
}
```
one could do:
```scala
item match {
      case TR.menu_item.sort() =>...
      case TR.menu_item.clear() =>...
      case _ => ...
}
```



